### PR TITLE
[FIX] Cache SW : confirmation du sync différée à la réception des données fraîches

### DIFF
--- a/frontend/src/components/SongList.test.tsx
+++ b/frontend/src/components/SongList.test.tsx
@@ -27,8 +27,11 @@ jest.mock('socket.io-client', () => ({
   }),
 }));
 
+import * as useMetaSyncModule from '../hooks/useMetaSync';
+
 jest.mock('../hooks/useMetaSync', () => ({
   useMetaSync: jest.fn(),
+  confirmPendingSync: jest.fn(),
 }));
 
 let broadcastOnMessage: (() => void) | null = null;
@@ -352,6 +355,8 @@ describe('Integration | Component | SongList', () => {
         ).length;
         expect(fetchCallsAfter).toBeGreaterThan(fetchCallsBefore);
       });
+
+      expect(useMetaSyncModule.confirmPendingSync).toHaveBeenCalled();
     });
   });
 

--- a/frontend/src/components/SongList.tsx
+++ b/frontend/src/components/SongList.tsx
@@ -10,7 +10,7 @@ import { fetchSongs, deleteSong } from '../api/songs';
 import { fetchPlaylistsPublic } from '../api/playlists';
 import { useSocket } from '../hooks/useSocket';
 import { useApiCacheUpdate } from '../hooks/useApiCacheUpdate';
-import { useMetaSync } from '../hooks/useMetaSync';
+import { useMetaSync, confirmPendingSync } from '../hooks/useMetaSync';
 import { useAuth } from '../contexts/AuthContext';
 import { useSearch } from '../contexts/SearchContext';
 import { SONG_EVENTS } from '../constants/events';
@@ -134,6 +134,11 @@ const SongList: React.FC = () => {
     void loadSongs();
   }, [loadSongs]);
 
+  const handleCacheUpdate = useCallback(() => {
+    confirmPendingSync();
+    void loadSongs();
+  }, [loadSongs]);
+
   const handleDeleteSong = useCallback(async (songId: string) => {
     if (!token) return;
     await deleteSong(songId, token);
@@ -153,7 +158,7 @@ const SongList: React.FC = () => {
   }, [withShuffleDelay]);
 
   useSocket(SONG_EVENTS.REFRESH, handleRefresh);
-  useApiCacheUpdate(handleRefresh);
+  useApiCacheUpdate(handleCacheUpdate);
   useMetaSync(loadSongs);
 
   const isShuffleActive = shuffledSong !== null;

--- a/frontend/src/hooks/useMetaSync.test.ts
+++ b/frontend/src/hooks/useMetaSync.test.ts
@@ -1,5 +1,5 @@
 import { renderHook, waitFor } from '@testing-library/react';
-import { useMetaSync } from './useMetaSync';
+import { useMetaSync, confirmPendingSync } from './useMetaSync';
 import * as metaApi from '../api/meta';
 
 jest.mock('../api/meta');
@@ -22,7 +22,7 @@ describe('useMetaSync', () => {
     await waitFor(() => expect(onRefresh).toHaveBeenCalledTimes(1));
   });
 
-  it('updates localStorage after refresh', async () => {
+  it('stores pendingSync with meta.updatedAt when stale', async () => {
     localStorage.setItem('lastSync', '2024-01-01T00:00:00.000Z');
     const updatedAt = '2024-06-01T00:00:00.000Z';
     mockFetchMeta.mockResolvedValue({ updatedAt });
@@ -30,7 +30,20 @@ describe('useMetaSync', () => {
 
     renderHook(() => useMetaSync(onRefresh));
 
-    await waitFor(() => expect(localStorage.getItem('lastSync')).toBe(updatedAt));
+    await waitFor(() => expect(onRefresh).toHaveBeenCalledTimes(1));
+    expect(localStorage.getItem('pendingSync')).toBe(updatedAt);
+  });
+
+  it('does NOT update lastSync after refresh', async () => {
+    localStorage.setItem('lastSync', '2024-01-01T00:00:00.000Z');
+    const updatedAt = '2024-06-01T00:00:00.000Z';
+    mockFetchMeta.mockResolvedValue({ updatedAt });
+    const onRefresh = jest.fn().mockResolvedValue(undefined);
+
+    renderHook(() => useMetaSync(onRefresh));
+
+    await waitFor(() => expect(onRefresh).toHaveBeenCalledTimes(1));
+    expect(localStorage.getItem('lastSync')).toBe('2024-01-01T00:00:00.000Z');
   });
 
   it('does not call onRefresh when meta.updatedAt equals lastSync', async () => {
@@ -65,7 +78,7 @@ describe('useMetaSync', () => {
     expect(() => unmount()).not.toThrow();
   });
 
-  it('does not update localStorage if onRefresh throws', async () => {
+  it('still sets pendingSync even if onRefresh throws', async () => {
     localStorage.setItem('lastSync', '2024-01-01T00:00:00.000Z');
     const updatedAt = '2024-06-01T00:00:00.000Z';
     mockFetchMeta.mockResolvedValue({ updatedAt });
@@ -73,8 +86,31 @@ describe('useMetaSync', () => {
 
     renderHook(() => useMetaSync(onRefresh));
 
-    await waitFor(() => expect(mockFetchMeta).toHaveBeenCalledTimes(1));
     await waitFor(() => expect(onRefresh).toHaveBeenCalledTimes(1));
+    expect(localStorage.getItem('pendingSync')).toBe(updatedAt);
+    expect(localStorage.getItem('lastSync')).toBe('2024-01-01T00:00:00.000Z');
+  });
+});
+
+describe('confirmPendingSync', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('promotes pendingSync to lastSync and removes pendingSync', () => {
+    localStorage.setItem('pendingSync', '2024-06-01T00:00:00.000Z');
+
+    confirmPendingSync();
+
+    expect(localStorage.getItem('lastSync')).toBe('2024-06-01T00:00:00.000Z');
+    expect(localStorage.getItem('pendingSync')).toBeNull();
+  });
+
+  it('does nothing when no pendingSync exists', () => {
+    localStorage.setItem('lastSync', '2024-01-01T00:00:00.000Z');
+
+    confirmPendingSync();
+
     expect(localStorage.getItem('lastSync')).toBe('2024-01-01T00:00:00.000Z');
   });
 });

--- a/frontend/src/hooks/useMetaSync.ts
+++ b/frontend/src/hooks/useMetaSync.ts
@@ -1,17 +1,25 @@
 import { useEffect } from 'react';
 import { fetchMeta } from '../api/meta';
 
-const LOCAL_STORAGE_KEY = 'lastSync';
+const LAST_SYNC_KEY = 'lastSync';
+const PENDING_SYNC_KEY = 'pendingSync';
+
+export function confirmPendingSync(): void {
+  const pending = localStorage.getItem(PENDING_SYNC_KEY);
+  if (!pending) return;
+  localStorage.setItem(LAST_SYNC_KEY, pending);
+  localStorage.removeItem(PENDING_SYNC_KEY);
+}
 
 export function useMetaSync(onRefresh: () => Promise<void>): void {
   useEffect(() => {
     fetchMeta()
       .then(async (meta) => {
-        const lastSync = localStorage.getItem(LOCAL_STORAGE_KEY);
+        const lastSync = localStorage.getItem(LAST_SYNC_KEY);
         const isStale = lastSync === null || meta.updatedAt > lastSync;
         if (!isStale) return;
+        localStorage.setItem(PENDING_SYNC_KEY, meta.updatedAt);
         await onRefresh();
-        localStorage.setItem(LOCAL_STORAGE_KEY, meta.updatedAt);
       })
       .catch(() => undefined);
   }, [onRefresh]);


### PR DESCRIPTION
StaleWhileRevalidate was updating lastSync immediately after loadSongs(), even though the SW had served stale cached data. On iOS, the SW background fetch could be killed before the broadcast fired, leaving lastSync updated but the cache still stale — breaking all subsequent retry attempts.

Now useMetaSync writes a pendingSync intent; confirmPendingSync() promotes it to lastSync only when the SW broadcast confirms fresh data arrived.