### PR TITLE
[FIX] WebSocket : émission REFRESH manquante sur toutes les mutations chanson et playlist

### DIFF
--- a/backend/src/application/usecases/AddSongToPlaylist.ts
+++ b/backend/src/application/usecases/AddSongToPlaylist.ts
@@ -1,8 +1,10 @@
-import type { ISongRepository } from '../../domain/interfaces/ISongRepository';
-import type { IPlaylistRepository } from '../../domain/interfaces/IPlaylistRepository';
-import type { IPlaylist } from '../../domain/interfaces/IPlaylist';
-import type { IMetaRepository } from '../../domain/interfaces/IMetaRepository';
-import { SongNotFoundError } from '../../domain/errors/DomainError';
+import type { ISongRepository } from "../../domain/interfaces/ISongRepository";
+import type { IPlaylistRepository } from "../../domain/interfaces/IPlaylistRepository";
+import type { IPlaylist } from "../../domain/interfaces/IPlaylist";
+import type { IEventEmitter } from "../interfaces/IEventEmitter";
+import type { IMetaRepository } from "../../domain/interfaces/IMetaRepository";
+import { SongNotFoundError } from "../../domain/errors/DomainError";
+import { SONG_EVENTS } from "../constants/events";
 
 export interface AddSongToPlaylistInput {
   playlistName: string;
@@ -18,6 +20,7 @@ export class AddSongToPlaylist {
     private readonly songRepository: ISongRepository,
     private readonly playlistRepository: IPlaylistRepository,
     private readonly metaRepository: IMetaRepository,
+    private readonly eventEmitter: IEventEmitter,
   ) {}
 
   async execute(input: AddSongToPlaylistInput): Promise<AddSongToPlaylistOutput> {
@@ -38,6 +41,8 @@ export class AddSongToPlaylist {
     });
 
     await this.metaRepository.touch();
+
+    this.eventEmitter.emit(SONG_EVENTS.REFRESH);
 
     return { playlist };
   }

--- a/backend/src/application/usecases/CreatePlaylist.ts
+++ b/backend/src/application/usecases/CreatePlaylist.ts
@@ -1,7 +1,9 @@
-import type { IPlaylistRepository } from '../../domain/interfaces/IPlaylistRepository';
-import type { IPlaylist } from '../../domain/interfaces/IPlaylist';
-import type { IMetaRepository } from '../../domain/interfaces/IMetaRepository';
-import { DuplicatePlaylistError } from '../../domain/errors/DomainError';
+import type { IPlaylistRepository } from "../../domain/interfaces/IPlaylistRepository";
+import type { IPlaylist } from "../../domain/interfaces/IPlaylist";
+import type { IEventEmitter } from "../interfaces/IEventEmitter";
+import type { IMetaRepository } from "../../domain/interfaces/IMetaRepository";
+import { DuplicatePlaylistError } from "../../domain/errors/DomainError";
+import { SONG_EVENTS } from "../constants/events";
 
 export interface CreatePlaylistInput {
   name: string;
@@ -15,6 +17,7 @@ export class CreatePlaylist {
   constructor(
     private readonly playlistRepository: IPlaylistRepository,
     private readonly metaRepository: IMetaRepository,
+    private readonly eventEmitter: IEventEmitter,
   ) {}
 
   async execute(input: CreatePlaylistInput): Promise<CreatePlaylistOutput> {
@@ -27,6 +30,8 @@ export class CreatePlaylist {
     });
 
     await this.metaRepository.touch();
+
+    this.eventEmitter.emit(SONG_EVENTS.REFRESH);
 
     return { playlist };
   }

--- a/backend/src/application/usecases/DeletePlaylist.ts
+++ b/backend/src/application/usecases/DeletePlaylist.ts
@@ -1,6 +1,8 @@
-import type { IPlaylistRepository } from '../../domain/interfaces/IPlaylistRepository';
-import type { IMetaRepository } from '../../domain/interfaces/IMetaRepository';
-import { PlaylistNotFoundError } from '../../domain/errors/DomainError';
+import type { IPlaylistRepository } from "../../domain/interfaces/IPlaylistRepository";
+import type { IEventEmitter } from "../interfaces/IEventEmitter";
+import type { IMetaRepository } from "../../domain/interfaces/IMetaRepository";
+import { PlaylistNotFoundError } from "../../domain/errors/DomainError";
+import { SONG_EVENTS } from "../constants/events";
 
 export interface DeletePlaylistInput {
   name: string;
@@ -10,6 +12,7 @@ export class DeletePlaylist {
   constructor(
     private readonly playlistRepository: IPlaylistRepository,
     private readonly metaRepository: IMetaRepository,
+    private readonly eventEmitter: IEventEmitter,
   ) {}
 
   async execute(input: DeletePlaylistInput): Promise<void> {
@@ -19,5 +22,7 @@ export class DeletePlaylist {
     await this.playlistRepository.deleteByName(input.name);
 
     await this.metaRepository.touch();
+
+    this.eventEmitter.emit(SONG_EVENTS.REFRESH);
   }
 }

--- a/backend/src/application/usecases/DeleteSong.ts
+++ b/backend/src/application/usecases/DeleteSong.ts
@@ -1,8 +1,10 @@
 import type { ISongRepository } from '../../domain/interfaces/ISongRepository';
 import type { IPlaylistRepository } from '../../domain/interfaces/IPlaylistRepository';
 import type { IFileUploadService } from '../interfaces/IFileUploadService';
+import type { IEventEmitter } from '../interfaces/IEventEmitter';
 import type { IMetaRepository } from '../../domain/interfaces/IMetaRepository';
 import { SongNotFoundError } from '../../domain/errors/DomainError';
+import { SONG_EVENTS } from '../constants/events';
 
 export interface DeleteSongInput {
   songId: string;
@@ -14,6 +16,7 @@ export class DeleteSong {
     private readonly playlistRepository: IPlaylistRepository,
     private readonly fileUploadService: IFileUploadService,
     private readonly metaRepository: IMetaRepository,
+    private readonly eventEmitter: IEventEmitter,
   ) {}
 
   async execute(input: DeleteSongInput): Promise<void> {
@@ -28,5 +31,7 @@ export class DeleteSong {
     await this.songRepository.deleteById(input.songId);
 
     await this.metaRepository.touch();
+
+    this.eventEmitter.emit(SONG_EVENTS.REFRESH);
   }
 }

--- a/backend/src/application/usecases/RemoveSongFromPlaylist.ts
+++ b/backend/src/application/usecases/RemoveSongFromPlaylist.ts
@@ -1,8 +1,10 @@
-import type { ISongRepository } from '../../domain/interfaces/ISongRepository';
-import type { IPlaylistRepository } from '../../domain/interfaces/IPlaylistRepository';
-import type { IPlaylist } from '../../domain/interfaces/IPlaylist';
-import type { IMetaRepository } from '../../domain/interfaces/IMetaRepository';
-import { PlaylistNotFoundError, SongNotFoundError } from '../../domain/errors/DomainError';
+import type { ISongRepository } from "../../domain/interfaces/ISongRepository";
+import type { IPlaylistRepository } from "../../domain/interfaces/IPlaylistRepository";
+import type { IPlaylist } from "../../domain/interfaces/IPlaylist";
+import type { IEventEmitter } from "../interfaces/IEventEmitter";
+import type { IMetaRepository } from "../../domain/interfaces/IMetaRepository";
+import { PlaylistNotFoundError, SongNotFoundError } from "../../domain/errors/DomainError";
+import { SONG_EVENTS } from "../constants/events";
 
 export interface RemoveSongFromPlaylistInput {
   playlistName: string;
@@ -18,6 +20,7 @@ export class RemoveSongFromPlaylist {
     private readonly songRepository: ISongRepository,
     private readonly playlistRepository: IPlaylistRepository,
     private readonly metaRepository: IMetaRepository,
+    private readonly eventEmitter: IEventEmitter,
   ) {}
 
   async execute(input: RemoveSongFromPlaylistInput): Promise<RemoveSongFromPlaylistOutput> {
@@ -35,6 +38,8 @@ export class RemoveSongFromPlaylist {
     });
 
     await this.metaRepository.touch();
+
+    this.eventEmitter.emit(SONG_EVENTS.REFRESH);
 
     return { playlist };
   }

--- a/backend/src/application/usecases/RenamePlaylist.ts
+++ b/backend/src/application/usecases/RenamePlaylist.ts
@@ -1,7 +1,9 @@
-import type { IPlaylistRepository } from '../../domain/interfaces/IPlaylistRepository';
-import type { IPlaylist } from '../../domain/interfaces/IPlaylist';
-import type { IMetaRepository } from '../../domain/interfaces/IMetaRepository';
-import { DuplicatePlaylistError, PlaylistNotFoundError } from '../../domain/errors/DomainError';
+import type { IPlaylistRepository } from "../../domain/interfaces/IPlaylistRepository";
+import type { IPlaylist } from "../../domain/interfaces/IPlaylist";
+import type { IEventEmitter } from "../interfaces/IEventEmitter";
+import type { IMetaRepository } from "../../domain/interfaces/IMetaRepository";
+import { DuplicatePlaylistError, PlaylistNotFoundError } from "../../domain/errors/DomainError";
+import { SONG_EVENTS } from "../constants/events";
 
 export interface RenamePlaylistInput {
   name: string;
@@ -16,6 +18,7 @@ export class RenamePlaylist {
   constructor(
     private readonly playlistRepository: IPlaylistRepository,
     private readonly metaRepository: IMetaRepository,
+    private readonly eventEmitter: IEventEmitter,
   ) {}
 
   async execute(input: RenamePlaylistInput): Promise<RenamePlaylistOutput> {
@@ -28,6 +31,8 @@ export class RenamePlaylist {
     const playlist = await this.playlistRepository.rename(input.name, input.newName);
 
     await this.metaRepository.touch();
+
+    this.eventEmitter.emit(SONG_EVENTS.REFRESH);
 
     return { playlist };
   }

--- a/backend/src/application/usecases/ReorderPlaylist.ts
+++ b/backend/src/application/usecases/ReorderPlaylist.ts
@@ -1,7 +1,9 @@
-import type { IPlaylistRepository } from '../../domain/interfaces/IPlaylistRepository';
-import type { IPlaylist } from '../../domain/interfaces/IPlaylist';
-import type { IMetaRepository } from '../../domain/interfaces/IMetaRepository';
-import { InvalidPlaylistSongError, PlaylistNotFoundError } from '../../domain/errors/DomainError';
+import type { IPlaylistRepository } from "../../domain/interfaces/IPlaylistRepository";
+import type { IPlaylist } from "../../domain/interfaces/IPlaylist";
+import type { IEventEmitter } from "../interfaces/IEventEmitter";
+import type { IMetaRepository } from "../../domain/interfaces/IMetaRepository";
+import { InvalidPlaylistSongError, PlaylistNotFoundError } from "../../domain/errors/DomainError";
+import { SONG_EVENTS } from "../constants/events";
 
 export interface ReorderPlaylistInput {
   playlistName: string;
@@ -16,6 +18,7 @@ export class ReorderPlaylist {
   constructor(
     private readonly playlistRepository: IPlaylistRepository,
     private readonly metaRepository: IMetaRepository,
+    private readonly eventEmitter: IEventEmitter,
   ) {}
 
   async execute(input: ReorderPlaylistInput): Promise<ReorderPlaylistOutput> {
@@ -34,6 +37,8 @@ export class ReorderPlaylist {
     });
 
     await this.metaRepository.touch();
+
+    this.eventEmitter.emit(SONG_EVENTS.REFRESH);
 
     return { playlist };
   }

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -46,7 +46,7 @@ app.use(monitoringRouter);
 const socketEventEmitter = new SocketEventEmitter(io);
 
 app.use('/api', createSongsRouter(socketEventEmitter));
-app.use('/api', createPlaylistsRouter());
+app.use('/api', createPlaylistsRouter(socketEventEmitter));
 app.use('/api', createMetaRouter());
 app.use('/api/auth', authRouter);
 app.use('/api/users', usersRouter);

--- a/backend/src/infrastructure/http/routes/playlists.ts
+++ b/backend/src/infrastructure/http/routes/playlists.ts
@@ -13,8 +13,9 @@ import { PlaylistRepository } from '../../repositories/playlistRepository';
 import { MetaRepository } from '../../repositories/metaRepository';
 import { authenticate } from '../middlewares/authenticate';
 import { requireAdmin } from '../middlewares/requireAdmin';
+import type { IEventEmitter } from '../../../application/interfaces/IEventEmitter';
 
-export function createPlaylistsRouter(): Router {
+export function createPlaylistsRouter(eventEmitter: IEventEmitter): Router {
   const router = Router();
 
   const songRepository = new SongRepository();
@@ -22,13 +23,13 @@ export function createPlaylistsRouter(): Router {
   const metaRepository = new MetaRepository();
 
   const getPlaylistUsecase = new GetPlaylist(songRepository, playlistRepository);
-  const reorderPlaylistUsecase = new ReorderPlaylist(playlistRepository, metaRepository);
-  const addSongToPlaylistUsecase = new AddSongToPlaylist(songRepository, playlistRepository, metaRepository);
-  const removeSongFromPlaylistUsecase = new RemoveSongFromPlaylist(songRepository, playlistRepository, metaRepository);
+  const reorderPlaylistUsecase = new ReorderPlaylist(playlistRepository, metaRepository, eventEmitter);
+  const addSongToPlaylistUsecase = new AddSongToPlaylist(songRepository, playlistRepository, metaRepository, eventEmitter);
+  const removeSongFromPlaylistUsecase = new RemoveSongFromPlaylist(songRepository, playlistRepository, metaRepository, eventEmitter);
   const getAllPlaylistsUsecase = new GetAllPlaylists(playlistRepository);
-  const createPlaylistUsecase = new CreatePlaylist(playlistRepository, metaRepository);
-  const renamePlaylistUsecase = new RenamePlaylist(playlistRepository, metaRepository);
-  const deletePlaylistUsecase = new DeletePlaylist(playlistRepository, metaRepository);
+  const createPlaylistUsecase = new CreatePlaylist(playlistRepository, metaRepository, eventEmitter);
+  const renamePlaylistUsecase = new RenamePlaylist(playlistRepository, metaRepository, eventEmitter);
+  const deletePlaylistUsecase = new DeletePlaylist(playlistRepository, metaRepository, eventEmitter);
 
   const controller = new PlaylistsController(
     getPlaylistUsecase,

--- a/backend/src/infrastructure/http/routes/songs.ts
+++ b/backend/src/infrastructure/http/routes/songs.ts
@@ -38,7 +38,7 @@ export function createSongsRouter(eventEmitter: IEventEmitter): Router {
     metaRepository,
   );
   const updateSongUsecase = new UpdateSong(songRepository, fileUploadService, eventEmitter, metaRepository);
-  const deleteSongUsecase = new DeleteSong(songRepository, playlistRepository, fileUploadService, metaRepository);
+  const deleteSongUsecase = new DeleteSong(songRepository, playlistRepository, fileUploadService, metaRepository, eventEmitter);
 
   const controller = new SongsController(
     getSongsUsecase,

--- a/backend/tests/unit/addSongToPlaylist.unit.test.ts
+++ b/backend/tests/unit/addSongToPlaylist.unit.test.ts
@@ -5,6 +5,7 @@ import type { IMetaRepository } from '../../src/domain/interfaces/IMetaRepositor
 import type { ISong } from '../../src/domain/interfaces/Song';
 import type { IPlaylist } from '../../src/domain/interfaces/IPlaylist';
 import { SongNotFoundError } from '../../src/domain/errors/DomainError';
+import type { IEventEmitter } from '../../src/application/interfaces/IEventEmitter';
 
 const buildSong = (id: string): ISong => ({
   id,
@@ -40,6 +41,10 @@ const buildMockMetaRepository = (overrides: Partial<IMetaRepository> = {}): IMet
   ...overrides,
 });
 
+const buildMockEventEmitter = (): IEventEmitter => ({
+  emit: jest.fn(),
+});
+
 describe('AddSongToPlaylist use case', () => {
   it('should add a song to an empty playlist when playlist does not exist', async () => {
     const song = buildSong('song-1');
@@ -51,7 +56,7 @@ describe('AddSongToPlaylist use case', () => {
       save: jest.fn().mockResolvedValue(savedPlaylist),
     });
 
-    const usecase = new AddSongToPlaylist(songRepository, playlistRepository, buildMockMetaRepository());
+    const usecase = new AddSongToPlaylist(songRepository, playlistRepository, buildMockMetaRepository(), buildMockEventEmitter());
     const { playlist } = await usecase.execute({ playlistName: 'rock', songId: 'song-1' });
 
     expect(playlistRepository.save).toHaveBeenCalledWith({ name: 'rock', songIds: ['song-1'] });
@@ -69,7 +74,7 @@ describe('AddSongToPlaylist use case', () => {
       save: jest.fn().mockResolvedValue(savedPlaylist),
     });
 
-    const usecase = new AddSongToPlaylist(songRepository, playlistRepository, buildMockMetaRepository());
+    const usecase = new AddSongToPlaylist(songRepository, playlistRepository, buildMockMetaRepository(), buildMockEventEmitter());
     const { playlist } = await usecase.execute({ playlistName: 'rock', songId: 'song-2' });
 
     expect(playlistRepository.save).toHaveBeenCalledWith({ name: 'rock', songIds: ['song-1', 'song-2'] });
@@ -86,7 +91,7 @@ describe('AddSongToPlaylist use case', () => {
       save: jest.fn().mockResolvedValue(existingPlaylist),
     });
 
-    const usecase = new AddSongToPlaylist(songRepository, playlistRepository, buildMockMetaRepository());
+    const usecase = new AddSongToPlaylist(songRepository, playlistRepository, buildMockMetaRepository(), buildMockEventEmitter());
     await usecase.execute({ playlistName: 'rock', songId: 'song-1' });
 
     expect(playlistRepository.save).toHaveBeenCalledWith({ name: 'rock', songIds: ['song-1'] });
@@ -96,7 +101,7 @@ describe('AddSongToPlaylist use case', () => {
     const songRepository = buildMockSongRepository({ findById: jest.fn().mockResolvedValue(null) });
     const playlistRepository = buildMockPlaylistRepository();
 
-    const usecase = new AddSongToPlaylist(songRepository, playlistRepository, buildMockMetaRepository());
+    const usecase = new AddSongToPlaylist(songRepository, playlistRepository, buildMockMetaRepository(), buildMockEventEmitter());
 
     await expect(usecase.execute({ playlistName: 'rock', songId: 'nonexistent' })).rejects.toThrow(SongNotFoundError);
     expect(playlistRepository.save).not.toHaveBeenCalled();

--- a/backend/tests/unit/createPlaylist.unit.test.ts
+++ b/backend/tests/unit/createPlaylist.unit.test.ts
@@ -3,6 +3,7 @@ import type { IPlaylistRepository } from '../../src/domain/interfaces/IPlaylistR
 import type { IMetaRepository } from '../../src/domain/interfaces/IMetaRepository';
 import type { IPlaylist } from '../../src/domain/interfaces/IPlaylist';
 import { DuplicatePlaylistError } from '../../src/domain/errors/DomainError';
+import type { IEventEmitter } from '../../src/application/interfaces/IEventEmitter';
 
 const buildMockPlaylistRepository = (overrides: Partial<IPlaylistRepository> = {}): IPlaylistRepository => ({
   findByName: jest.fn().mockResolvedValue(null),
@@ -20,6 +21,10 @@ const buildMockMetaRepository = (overrides: Partial<IMetaRepository> = {}): IMet
   ...overrides,
 });
 
+const buildMockEventEmitter = (): IEventEmitter => ({
+  emit: jest.fn(),
+});
+
 describe('CreatePlaylist use case', () => {
   it('should create a new playlist with empty songIds', async () => {
     const savedPlaylist: IPlaylist = { id: 'pl-1', name: 'rock', songIds: [] };
@@ -28,7 +33,7 @@ describe('CreatePlaylist use case', () => {
       save: jest.fn().mockResolvedValue(savedPlaylist),
     });
 
-    const usecase = new CreatePlaylist(playlistRepository, buildMockMetaRepository());
+    const usecase = new CreatePlaylist(playlistRepository, buildMockMetaRepository(), buildMockEventEmitter());
     const { playlist } = await usecase.execute({ name: 'rock' });
 
     expect(playlistRepository.save).toHaveBeenCalledWith({ name: 'rock', songIds: [] });
@@ -41,7 +46,7 @@ describe('CreatePlaylist use case', () => {
       findByName: jest.fn().mockResolvedValue(existingPlaylist),
     });
 
-    const usecase = new CreatePlaylist(playlistRepository, buildMockMetaRepository());
+    const usecase = new CreatePlaylist(playlistRepository, buildMockMetaRepository(), buildMockEventEmitter());
 
     await expect(usecase.execute({ name: 'rock' })).rejects.toThrow(DuplicatePlaylistError);
     expect(playlistRepository.save).not.toHaveBeenCalled();

--- a/backend/tests/unit/deletePlaylist.unit.test.ts
+++ b/backend/tests/unit/deletePlaylist.unit.test.ts
@@ -3,6 +3,7 @@ import type { IPlaylistRepository } from '../../src/domain/interfaces/IPlaylistR
 import type { IMetaRepository } from '../../src/domain/interfaces/IMetaRepository';
 import type { IPlaylist } from '../../src/domain/interfaces/IPlaylist';
 import { PlaylistNotFoundError } from '../../src/domain/errors/DomainError';
+import type { IEventEmitter } from '../../src/application/interfaces/IEventEmitter';
 
 const buildMockPlaylistRepository = (overrides: Partial<IPlaylistRepository> = {}): IPlaylistRepository => ({
   findByName: jest.fn().mockResolvedValue(null),
@@ -20,6 +21,10 @@ const buildMockMetaRepository = (overrides: Partial<IMetaRepository> = {}): IMet
   ...overrides,
 });
 
+const buildMockEventEmitter = (): IEventEmitter => ({
+  emit: jest.fn(),
+});
+
 describe('DeletePlaylist use case', () => {
   it('should delete an existing playlist', async () => {
     const existingPlaylist: IPlaylist = { id: 'pl-1', name: 'rock', songIds: [] };
@@ -28,7 +33,7 @@ describe('DeletePlaylist use case', () => {
       deleteByName: jest.fn().mockResolvedValue(undefined),
     });
 
-    const usecase = new DeletePlaylist(playlistRepository, buildMockMetaRepository());
+    const usecase = new DeletePlaylist(playlistRepository, buildMockMetaRepository(), buildMockEventEmitter());
     await usecase.execute({ name: 'rock' });
 
     expect(playlistRepository.deleteByName).toHaveBeenCalledWith('rock');
@@ -39,7 +44,7 @@ describe('DeletePlaylist use case', () => {
       findByName: jest.fn().mockResolvedValue(null),
     });
 
-    const usecase = new DeletePlaylist(playlistRepository, buildMockMetaRepository());
+    const usecase = new DeletePlaylist(playlistRepository, buildMockMetaRepository(), buildMockEventEmitter());
 
     await expect(usecase.execute({ name: 'nonexistent' })).rejects.toThrow(PlaylistNotFoundError);
     expect(playlistRepository.deleteByName).not.toHaveBeenCalled();

--- a/backend/tests/unit/deleteSong.unit.test.ts
+++ b/backend/tests/unit/deleteSong.unit.test.ts
@@ -6,6 +6,7 @@ import type { IMetaRepository } from '../../src/domain/interfaces/IMetaRepositor
 import type { ISong } from '../../src/domain/interfaces/Song';
 import type { IPlaylist } from '../../src/domain/interfaces/IPlaylist';
 import { SongNotFoundError } from '../../src/domain/errors/DomainError';
+import type { IEventEmitter } from '../../src/application/interfaces/IEventEmitter';
 
 const buildSong = (id: string, tab = ''): ISong => ({
   id,
@@ -47,6 +48,10 @@ const buildMockMetaRepository = (overrides: Partial<IMetaRepository> = {}): IMet
   ...overrides,
 });
 
+const buildMockEventEmitter = (): IEventEmitter => ({
+  emit: jest.fn(),
+});
+
 describe('DeleteSong use case', () => {
   it('should delete the song, remove it from all playlists, and delete its S3 image', async () => {
     const song = buildSong('song-1', 'https://bucket.s3.amazonaws.com/image.jpg');
@@ -55,7 +60,7 @@ describe('DeleteSong use case', () => {
     const playlistRepository = buildMockPlaylistRepository();
     const fileUploadService = buildMockFileUploadService();
 
-    const usecase = new DeleteSong(songRepository, playlistRepository, fileUploadService, buildMockMetaRepository());
+    const usecase = new DeleteSong(songRepository, playlistRepository, fileUploadService, buildMockMetaRepository(), buildMockEventEmitter());
     await usecase.execute({ songId: 'song-1' });
 
     expect(fileUploadService.delete).toHaveBeenCalledWith('https://bucket.s3.amazonaws.com/image.jpg');
@@ -70,7 +75,7 @@ describe('DeleteSong use case', () => {
     const playlistRepository = buildMockPlaylistRepository();
     const fileUploadService = buildMockFileUploadService();
 
-    const usecase = new DeleteSong(songRepository, playlistRepository, fileUploadService, buildMockMetaRepository());
+    const usecase = new DeleteSong(songRepository, playlistRepository, fileUploadService, buildMockMetaRepository(), buildMockEventEmitter());
     await usecase.execute({ songId: 'song-1' });
 
     expect(fileUploadService.delete).not.toHaveBeenCalled();
@@ -83,7 +88,7 @@ describe('DeleteSong use case', () => {
     const playlistRepository = buildMockPlaylistRepository();
     const fileUploadService = buildMockFileUploadService();
 
-    const usecase = new DeleteSong(songRepository, playlistRepository, fileUploadService, buildMockMetaRepository());
+    const usecase = new DeleteSong(songRepository, playlistRepository, fileUploadService, buildMockMetaRepository(), buildMockEventEmitter());
 
     await expect(usecase.execute({ songId: 'nonexistent' })).rejects.toThrow(SongNotFoundError);
     expect(playlistRepository.removeSongFromAll).not.toHaveBeenCalled();
@@ -110,7 +115,7 @@ describe('DeleteSong use case', () => {
     });
     const fileUploadService = buildMockFileUploadService();
 
-    const usecase = new DeleteSong(songRepository, playlistRepository, fileUploadService, buildMockMetaRepository());
+    const usecase = new DeleteSong(songRepository, playlistRepository, fileUploadService, buildMockMetaRepository(), buildMockEventEmitter());
     await usecase.execute({ songId: 'song-1' });
 
     expect(callOrder).toEqual(['removeSongFromAll', 'deleteById']);

--- a/backend/tests/unit/removeSongFromPlaylist.unit.test.ts
+++ b/backend/tests/unit/removeSongFromPlaylist.unit.test.ts
@@ -5,6 +5,7 @@ import type { IMetaRepository } from '../../src/domain/interfaces/IMetaRepositor
 import type { ISong } from '../../src/domain/interfaces/Song';
 import type { IPlaylist } from '../../src/domain/interfaces/IPlaylist';
 import { PlaylistNotFoundError, SongNotFoundError } from '../../src/domain/errors/DomainError';
+import type { IEventEmitter } from '../../src/application/interfaces/IEventEmitter';
 
 const buildSong = (id: string): ISong => ({
   id,
@@ -40,6 +41,10 @@ const buildMockMetaRepository = (overrides: Partial<IMetaRepository> = {}): IMet
   ...overrides,
 });
 
+const buildMockEventEmitter = (): IEventEmitter => ({
+  emit: jest.fn(),
+});
+
 describe('RemoveSongFromPlaylist use case', () => {
   it('should remove the song from the playlist', async () => {
     const song = buildSong('song-1');
@@ -52,7 +57,7 @@ describe('RemoveSongFromPlaylist use case', () => {
       save: jest.fn().mockResolvedValue(savedPlaylist),
     });
 
-    const usecase = new RemoveSongFromPlaylist(songRepository, playlistRepository, buildMockMetaRepository());
+    const usecase = new RemoveSongFromPlaylist(songRepository, playlistRepository, buildMockMetaRepository(), buildMockEventEmitter());
     const { playlist } = await usecase.execute({ playlistName: 'rock', songId: 'song-1' });
 
     expect(playlistRepository.save).toHaveBeenCalledWith({ name: 'rock', songIds: ['song-2'] });
@@ -70,7 +75,7 @@ describe('RemoveSongFromPlaylist use case', () => {
       save: jest.fn().mockResolvedValue(savedPlaylist),
     });
 
-    const usecase = new RemoveSongFromPlaylist(songRepository, playlistRepository, buildMockMetaRepository());
+    const usecase = new RemoveSongFromPlaylist(songRepository, playlistRepository, buildMockMetaRepository(), buildMockEventEmitter());
     const { playlist } = await usecase.execute({ playlistName: 'rock', songId: 'song-1' });
 
     expect(playlistRepository.save).toHaveBeenCalledWith({ name: 'rock', songIds: [] });
@@ -83,7 +88,7 @@ describe('RemoveSongFromPlaylist use case', () => {
       findByName: jest.fn().mockResolvedValue(null),
     });
 
-    const usecase = new RemoveSongFromPlaylist(songRepository, playlistRepository, buildMockMetaRepository());
+    const usecase = new RemoveSongFromPlaylist(songRepository, playlistRepository, buildMockMetaRepository(), buildMockEventEmitter());
 
     await expect(
       usecase.execute({ playlistName: 'nonexistent', songId: 'song-1' }),
@@ -98,7 +103,7 @@ describe('RemoveSongFromPlaylist use case', () => {
       findByName: jest.fn().mockResolvedValue(existingPlaylist),
     });
 
-    const usecase = new RemoveSongFromPlaylist(songRepository, playlistRepository, buildMockMetaRepository());
+    const usecase = new RemoveSongFromPlaylist(songRepository, playlistRepository, buildMockMetaRepository(), buildMockEventEmitter());
 
     await expect(
       usecase.execute({ playlistName: 'rock', songId: 'nonexistent' }),

--- a/backend/tests/unit/renamePlaylist.unit.test.ts
+++ b/backend/tests/unit/renamePlaylist.unit.test.ts
@@ -3,6 +3,7 @@ import type { IPlaylistRepository } from '../../src/domain/interfaces/IPlaylistR
 import type { IMetaRepository } from '../../src/domain/interfaces/IMetaRepository';
 import type { IPlaylist } from '../../src/domain/interfaces/IPlaylist';
 import { DuplicatePlaylistError, PlaylistNotFoundError } from '../../src/domain/errors/DomainError';
+import type { IEventEmitter } from '../../src/application/interfaces/IEventEmitter';
 
 const buildMockPlaylistRepository = (overrides: Partial<IPlaylistRepository> = {}): IPlaylistRepository => ({
   findByName: jest.fn().mockResolvedValue(null),
@@ -20,6 +21,10 @@ const buildMockMetaRepository = (overrides: Partial<IMetaRepository> = {}): IMet
   ...overrides,
 });
 
+const buildMockEventEmitter = (): IEventEmitter => ({
+  emit: jest.fn(),
+});
+
 describe('RenamePlaylist use case', () => {
   it('should rename an existing playlist to a new unique name', async () => {
     const existingPlaylist: IPlaylist = { id: 'pl-1', name: 'rock', songIds: ['song-1'] };
@@ -34,7 +39,7 @@ describe('RenamePlaylist use case', () => {
       rename: jest.fn().mockResolvedValue(renamedPlaylist),
     });
 
-    const usecase = new RenamePlaylist(playlistRepository, buildMockMetaRepository());
+    const usecase = new RenamePlaylist(playlistRepository, buildMockMetaRepository(), buildMockEventEmitter());
     const { playlist } = await usecase.execute({ name: 'rock', newName: 'hard-rock' });
 
     expect(playlistRepository.rename).toHaveBeenCalledWith('rock', 'hard-rock');
@@ -46,7 +51,7 @@ describe('RenamePlaylist use case', () => {
       findByName: jest.fn().mockResolvedValue(null),
     });
 
-    const usecase = new RenamePlaylist(playlistRepository, buildMockMetaRepository());
+    const usecase = new RenamePlaylist(playlistRepository, buildMockMetaRepository(), buildMockEventEmitter());
 
     await expect(usecase.execute({ name: 'nonexistent', newName: 'new-name' })).rejects.toThrow(PlaylistNotFoundError);
     expect(playlistRepository.rename).not.toHaveBeenCalled();
@@ -64,7 +69,7 @@ describe('RenamePlaylist use case', () => {
       findByName,
     });
 
-    const usecase = new RenamePlaylist(playlistRepository, buildMockMetaRepository());
+    const usecase = new RenamePlaylist(playlistRepository, buildMockMetaRepository(), buildMockEventEmitter());
 
     await expect(usecase.execute({ name: 'rock', newName: 'pop' })).rejects.toThrow(DuplicatePlaylistError);
     expect(playlistRepository.rename).not.toHaveBeenCalled();

--- a/backend/tests/unit/reorderPlaylist.unit.test.ts
+++ b/backend/tests/unit/reorderPlaylist.unit.test.ts
@@ -3,6 +3,7 @@ import type { IPlaylistRepository } from '../../src/domain/interfaces/IPlaylistR
 import type { IMetaRepository } from '../../src/domain/interfaces/IMetaRepository';
 import type { IPlaylist } from '../../src/domain/interfaces/IPlaylist';
 import { InvalidPlaylistSongError, PlaylistNotFoundError } from '../../src/domain/errors/DomainError';
+import type { IEventEmitter } from '../../src/application/interfaces/IEventEmitter';
 
 const buildMockPlaylistRepository = (overrides: Partial<IPlaylistRepository> = {}): IPlaylistRepository => ({
   findByName: jest.fn().mockResolvedValue(null),
@@ -20,6 +21,10 @@ const buildMockMetaRepository = (overrides: Partial<IMetaRepository> = {}): IMet
   ...overrides,
 });
 
+const buildMockEventEmitter = (): IEventEmitter => ({
+  emit: jest.fn(),
+});
+
 describe('ReorderPlaylist use case', () => {
   it('should save playlist with new song order', async () => {
     const existingPlaylist: IPlaylist = { name: 'rock', songIds: ['song-1', 'song-2', 'song-3'] };
@@ -29,7 +34,7 @@ describe('ReorderPlaylist use case', () => {
       save: jest.fn().mockResolvedValue(savedPlaylist),
     });
 
-    const usecase = new ReorderPlaylist(playlistRepository, buildMockMetaRepository());
+    const usecase = new ReorderPlaylist(playlistRepository, buildMockMetaRepository(), buildMockEventEmitter());
     const { playlist } = await usecase.execute({
       playlistName: 'rock',
       songIds: ['song-3', 'song-1', 'song-2'],
@@ -48,7 +53,7 @@ describe('ReorderPlaylist use case', () => {
       findByName: jest.fn().mockResolvedValue(existingPlaylist),
     });
 
-    const usecase = new ReorderPlaylist(playlistRepository, buildMockMetaRepository());
+    const usecase = new ReorderPlaylist(playlistRepository, buildMockMetaRepository(), buildMockEventEmitter());
 
     await expect(
       usecase.execute({ playlistName: 'rock', songIds: ['song-1', 'song-99'] }),
@@ -62,7 +67,7 @@ describe('ReorderPlaylist use case', () => {
       findByName: jest.fn().mockResolvedValue(null),
     });
 
-    const usecase = new ReorderPlaylist(playlistRepository, buildMockMetaRepository());
+    const usecase = new ReorderPlaylist(playlistRepository, buildMockMetaRepository(), buildMockEventEmitter());
 
     await expect(
       usecase.execute({ playlistName: 'nonexistent', songIds: [] }),

--- a/frontend/src/api/playlists.ts
+++ b/frontend/src/api/playlists.ts
@@ -23,8 +23,10 @@ export async function fetchPlaylists(token: string): Promise<Playlist[]> {
   return (await res.json()) as Playlist[];
 }
 
-export async function fetchPlaylistsPublic(): Promise<Playlist[]> {
-  const res = await fetch(`${API_BASE_URL}/api/playlists`);
+export async function fetchPlaylistsPublic(options?: { force?: boolean }): Promise<Playlist[]> {
+  const base = `${API_BASE_URL}/api/playlists`;
+  const url = options?.force ? `${base}?_t=${Date.now()}` : base;
+  const res = await fetch(url);
 
   if (!res.ok) throw new Error('Erreur lors du chargement des playlists');
 

--- a/frontend/src/api/songs.ts
+++ b/frontend/src/api/songs.ts
@@ -2,8 +2,10 @@ import type { Song } from '../types/song';
 import { API_BASE_URL } from './config';
 import { handleApiResponseError } from '../utils/apiErrorHandling';
 
-export async function fetchSongs(): Promise<Song[]> {
-  const res = await fetch(`${API_BASE_URL}/api/songs?sortBy=title`);
+export async function fetchSongs(options?: { force?: boolean }): Promise<Song[]> {
+  const base = `${API_BASE_URL}/api/songs?sortBy=title`;
+  const url = options?.force ? `${base}&_t=${Date.now()}` : base;
+  const res = await fetch(url);
   if (!res.ok) throw new Error('Erreur lors du chargement des chansons');
   const parsedResponse = await res.json() as unknown;
 

--- a/frontend/src/components/SongList.tsx
+++ b/frontend/src/components/SongList.tsx
@@ -74,13 +74,13 @@ const SongList: React.FC = () => {
     }, SHUFFLE_DELAY_MS);
   }, []);
 
-  const loadSongs = useCallback(async () => {
+  const loadSongs = useCallback(async (force = false) => {
     setLoading(true);
     setError(null);
     try {
       const [data, playlistsData] = await Promise.all([
-        fetchSongs(),
-        fetchPlaylistsPublic(),
+        fetchSongs({ force }),
+        fetchPlaylistsPublic({ force }),
         new Promise<void>((resolve) => setTimeout(resolve, MIN_LOADING_DURATION_MS)),
       ]);
       setSongs(data);
@@ -130,8 +130,13 @@ const SongList: React.FC = () => {
     setPendingPlaylistName(name);
   }, [withShuffleDelay]);
 
+  const forceLoadSongs = useCallback(async () => {
+    await loadSongs(true);
+    confirmPendingSync();
+  }, [loadSongs]);
+
   const handleRefresh = useCallback(() => {
-    void loadSongs();
+    void loadSongs(true);
   }, [loadSongs]);
 
   const handleCacheUpdate = useCallback(() => {
@@ -159,7 +164,7 @@ const SongList: React.FC = () => {
 
   useSocket(SONG_EVENTS.REFRESH, handleRefresh);
   useApiCacheUpdate(handleCacheUpdate);
-  useMetaSync(loadSongs);
+  useMetaSync(forceLoadSongs);
 
   const isShuffleActive = shuffledSong !== null;
   const effectivePlaylistName = pendingPlaylistName ?? selectedPlaylistName;


### PR DESCRIPTION
…ions

DeleteSong, CreatePlaylist, DeletePlaylist, RenamePlaylist, ReorderPlaylist, AddSongToPlaylist and RemoveSongFromPlaylist were updating the meta timestamp but never emitting the socket REFRESH event — connected clients received no real-time notification. createPlaylistsRouter now receives the eventEmitter.

On the frontend, triggered refreshes (socket, meta-sync) now bypass the SW cache via a timestamped URL, guaranteeing fresh data without waiting for the StaleWhileRevalidate background fetch to complete and broadcast.