### PR TITLE
[FIX] Suppression d'une chanson : bypass cache SW lors du broadcast pour éviter la réapparition

### DIFF
--- a/frontend/src/components/SongList.tsx
+++ b/frontend/src/components/SongList.tsx
@@ -141,7 +141,7 @@ const SongList: React.FC = () => {
 
   const handleCacheUpdate = useCallback(() => {
     confirmPendingSync();
-    void loadSongs();
+    void loadSongs(true);
   }, [loadSongs]);
 
   const handleDeleteSong = useCallback(async (songId: string) => {


### PR DESCRIPTION
…ter delete

When the Service Worker broadcasts a cache update (StaleWhileRevalidate background fetch), handleCacheUpdate was calling loadSongs() without force, causing the SW to serve its old cached response — which still contained the deleted song — overwriting the optimistic update.